### PR TITLE
Add build arg 'CACHE_DATE'

### DIFF
--- a/base/minimal-notebook/Dockerfile
+++ b/base/minimal-notebook/Dockerfile
@@ -38,7 +38,10 @@ RUN pip install pip==9.0.3 \
     && pip install -U h5py \
     && rm -rf ~/.cache/pip
 
+# Disable cache for the following instructions
+# When build, use docker build --build-arg CACHE_DATE="$(date)"
+ARG CACHE_DATE
 # Install aiforge command line tool for all base images.
-RUN wget https://raw.githubusercontent.com/linkernetworks/aiforge/master/install.sh -O - | bash    
+RUN wget https://raw.githubusercontent.com/linkernetworks/aiforge/master/install.sh -O - | bash
 
 WORKDIR /workspace


### PR DESCRIPTION
## Issue
The aiforge binary may not be newest when the Console image is built  #26 

## Solution
Disable docker build cache on the installation instruction.