### PR TITLE
Build Caffe2 from source

### DIFF
--- a/env/caffe2/Dockerfile
+++ b/env/caffe2/Dockerfile
@@ -1,6 +1,32 @@
 FROM linkernetworks/minimal-notebook:master
 
-RUN conda install --quiet --yes -c caffe2 \
-    caffe2==0.8.dev \
-    && conda clean -tipsy \
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    libgflags-dev \
+    libgoogle-glog-dev \
+    libgtest-dev \
+    libiomp-dev \
+    libleveldb-dev \
+    liblmdb-dev \
+    libopencv-dev \
+    libopenmpi-dev \
+    libprotobuf-dev \
+    libsnappy-dev \
+    openmpi-bin \
+    openmpi-doc \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN conda install --quiet --yes \
+    future numpy protobuf \
+    && conda clean -tipsy \ 
     && fix-permissions $CONDA_DIR
+
+RUN git clone https://github.com/pytorch/pytorch.git /tmp/pytorch \
+    && (cd /tmp/pytorch \
+    && git checkout v0.4.0 \
+    && git submodule update --init \
+    && python setup_caffe2.py install) \
+    && rm -rf /tmp/*

--- a/env/caffe2/Dockerfile.gpu
+++ b/env/caffe2/Dockerfile.gpu
@@ -24,8 +24,10 @@ RUN conda install --quiet --yes \
     && conda clean -tipsy \ 
     && fix-permissions $CONDA_DIR
 
-RUN git clone --recursive https://github.com/pytorch/pytorch.git /tmp/pytorch \
-    && ( cd /tmp/pytorch \
-    && python setup_caffe2.py install ) \
+RUN git clone https://github.com/pytorch/pytorch.git /tmp/pytorch \
+    && (cd /tmp/pytorch \
+    && git checkout v0.4.0 \
+    && git submodule update --init \
+    && python setup_caffe2.py install) \
     && rm -rf /tmp/*
 


### PR DESCRIPTION
```
WARNING:root:This caffe2 python run does not have GPU support. Will run in CPU only mode.
WARNING:root:Debug message: No module named 'caffe2.python.caffe2_pybind11_state_gpu'
CRITICAL:root:Cannot load caffe2.python. Error: /opt/conda/lib/python3.6/site-packages/caffe2/python/../../../../libcaffe2.so: undefined symbol: _ZN6google15SetUsageMessageERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
CRITICAL:root:Cannot load caffe2.python. Error: /opt/conda/lib/python3.6/site-packages/caffe2/python/../../../../libcaffe2.so: undefined symbol: _ZN6google15SetUsageMessageERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
```
To fix this bug, we build Caffe2 from source instead of installing Caff2 from Anaconda cloud.