### PR TITLE
FIX #42 : Current make notebook images only one framework version #42

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ notebook-images: $(NOTEBOOK_TARGETS)
 base-images: $(BASE_TARGETS)
 
 list-images:
-	@echo $(NOTEBOOK_VER)
+	@echo $(NOTEBOOK_TARGETS) $(BASE_TARGETS)
 
 clean: clean-notebook-images
 

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,6 @@ NOTEBOOK_VER := $(subst /,-,$(NOTEBOOK_DIRS))
 NOTEBOOK_NAMES := $(patsubst env-%,%,$(NOTEBOOK_VER))
 NOTEBOOK_TARGETS := $(addprefix notebook-image-,$(NOTEBOOK_NAMES))
 
-debug:
-	@echo $(NOTEBOOK_TARGETS)
-
 BASE_DOCKERFILES := $(sort $(wildcard base/*/Dockerfile$(DOCKERFILE_VARIANT)))
 BASE_DIRS := $(patsubst %/Dockerfile,%,$(basename $(BASE_DOCKERFILES)))
 BASE_NAMES := $(notdir $(BASE_DIRS))

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ all: base-images push-base-images notebook-images push-notebook-images
 # the first pattern % will locate the Dockerfile,
 # the given DOCKERFILE_VARIANT can be used for specifying which Dockerfile to use.
 # when DOCKERFILE_VARIANT is given, the tag :latest won't be used.
-notebook-image-%: env/%/*/Dockerfile$(DOCKERFILE_VARIANT) $(shell find env/* -type f)
+notebook-image-%: env/$(firstword $(subst :, ,%))/Dockerfile$(DOCKERFILE_VARIANT) $(shell find env -type f)
+	@echo 
 ifeq ($(strip $(DOCKERFILE_VARIANT)),)
 	@echo $(PUBLIC_DOCKER_REGISTRY)/$(DOCKER_PROJECT)/$*:$(notdir $(patsubst %/Dockerfile,%,$(basename $<)))
 #		--tag $(PUBLIC_DOCKER_REGISTRY)/$(DOCKER_PROJECT)/$*:$(notdir $(patsubst %/Dockerfile,%,$(basename $<))) \

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,12 @@ endif
 # DOCKER_BUILD_FLAGS=--quiet
 NOTEBOOK_DOCKERFILES := $(sort $(wildcard env/*/*/Dockerfile$(DOCKERFILE_VARIANT)))
 NOTEBOOK_DIRS := $(patsubst %/Dockerfile,%,$(basename $(NOTEBOOK_DOCKERFILES)))
-NOTEBOOK_VER := $(patsubst %/,%,$(dir $(NOTEBOOK_DIRS)))
-NOTEBOOK_NAMES := $(notdir $(NOTEBOOK_VER))
+NOTEBOOK_VER := $(subst /,-,$(NOTEBOOK_DIRS))
+NOTEBOOK_NAMES := $(patsubst env-%,%,$(NOTEBOOK_VER))
 NOTEBOOK_TARGETS := $(addprefix notebook-image-,$(NOTEBOOK_NAMES))
+
+debug:
+	@echo $(NOTEBOOK_TARGETS)
 
 BASE_DOCKERFILES := $(sort $(wildcard base/*/Dockerfile$(DOCKERFILE_VARIANT)))
 BASE_DIRS := $(patsubst %/Dockerfile,%,$(basename $(BASE_DOCKERFILES)))
@@ -50,10 +53,10 @@ all: base-images push-base-images notebook-images push-notebook-images
 # the first pattern % will locate the Dockerfile,
 # the given DOCKERFILE_VARIANT can be used for specifying which Dockerfile to use.
 # when DOCKERFILE_VARIANT is given, the tag :latest won't be used.
-notebook-image-%: env/%/*/Dockerfile$(DOCKERFILE_VARIANT) $(shell find env/$* -type f)
+notebook-image-%: env/%/*/Dockerfile$(DOCKERFILE_VARIANT) $(shell find env/* -type f)
 ifeq ($(strip $(DOCKERFILE_VARIANT)),)
-	time docker build $(DOCKER_BUILD_FLAGS) \
-		--tag $(PUBLIC_DOCKER_REGISTRY)/$(DOCKER_PROJECT)/$*:$(notdir $(patsubst %/Dockerfile,%,$(basename $<))) \
+	@echo $(PUBLIC_DOCKER_REGISTRY)/$(DOCKER_PROJECT)/$*:$(notdir $(patsubst %/Dockerfile,%,$(basename $<)))
+#		--tag $(PUBLIC_DOCKER_REGISTRY)/$(DOCKER_PROJECT)/$*:$(notdir $(patsubst %/Dockerfile,%,$(basename $<))) \
 		--file $< \
 		$(dir $<)
 else
@@ -88,7 +91,7 @@ notebook-images: $(NOTEBOOK_TARGETS)
 base-images: $(BASE_TARGETS)
 
 list-images:
-	@echo $(NOTEBOOK_TARGETS) $(BASE_TARGETS)
+	@echo $(NOTEBOOK_VER)
 
 clean: clean-notebook-images
 

--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,11 @@ all: base-images push-base-images notebook-images push-notebook-images
 # the first pattern % will locate the Dockerfile,
 # the given DOCKERFILE_VARIANT can be used for specifying which Dockerfile to use.
 # when DOCKERFILE_VARIANT is given, the tag :latest won't be used.
-notebook-image-%: env/$(firstword $(subst :, ,%))/Dockerfile$(DOCKERFILE_VARIANT) $(shell find env -type f)
-	@echo 
+.SECONDEXPANSION:
+notebook-image-%: env/$$(subst -,/,%)/Dockerfile$(DOCKERFILE_VARIANT) $$(shell find env -type f)
 ifeq ($(strip $(DOCKERFILE_VARIANT)),)
-	@echo $(PUBLIC_DOCKER_REGISTRY)/$(DOCKER_PROJECT)/$*:$(notdir $(patsubst %/Dockerfile,%,$(basename $<)))
-#		--tag $(PUBLIC_DOCKER_REGISTRY)/$(DOCKER_PROJECT)/$*:$(notdir $(patsubst %/Dockerfile,%,$(basename $<))) \
+	time docker build $(DOCKER_BUILD_FLAGS) \
+		--tag $(PUBLIC_DOCKER_REGISTRY)/$(DOCKER_PROJECT)/$*:$(notdir $(patsubst %/Dockerfile,%,$(basename $<))) \
 		--file $< \
 		$(dir $<)
 else


### PR DESCRIPTION
**Problem:**

- Only run pytorch/0.3.1/Dockerfile, but not build pytorch/0.4.0/Dockerfile

**Solution:**

- Use `SECONDEXPANSION` to expansion percentage sign
Refer: https://stackoverflow.com/questions/50494899/how-to-replace-string-in-in-make-file/50495957#50495957

https://www.gnu.org/software/make/manual/html_node/Secondary-Expansion.html 

**Side Effect:**

- None
