### PR TITLE
Add option to control build environments images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,49 @@ class ImageConfig {
 }
 
 def getStages(configs) {
-    return configs.collectEntries { config ->
+
+    def filteredConfigs = configs
+
+    if ( !shouldDeploy() && params.BuildIfFileChanged) {
+        def label = "environments-pod-${UUID.randomUUID().toString()}"
+        podTemplate(label: label, nodeUsageMode: 'EXCLUSIVE', yaml: """
+apiVersion: v1
+kind: Pod
+spec:
+    """
+        ) {
+            node (label) {
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: '*/master']],
+                    doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
+                    userRemoteConfigs: scm.userRemoteConfigs
+                ])
+
+                checkout scm
+
+                def allFiles = sh(
+                        returnStdout: true,
+                        script: 'git diff --name-only refs/remotes/origin/master HEAD'
+                    ).trim().split("\n")
+
+                filteredConfigs = filteredConfigs.findAll { config ->
+                    def dir = new File(config.folder)
+                    def changedFiles = allFiles.findAll { new File(it).getPath().contains(dir.getPath()) }
+                    if (changedFiles.size() > 0) {
+                        echo "${config.tag}: ${changedFiles.size()} files are changed"
+                        changedFiles.each { echo "${config.tag}: ${it}" }
+                        return true
+                    } else {
+                        echo "${config.tag}: No file is changed. Skip."
+                        return false
+                    }
+                }
+            }
+        }
+    }
+
+    return filteredConfigs.collectEntries { config ->
         [(config.tag): {
             retry (3) {
                 timeout(90) {
@@ -117,6 +159,12 @@ pipeline {
             defaultValue: false,
             description: 'If true, jenkins will build all base images. ' +
                 'If current branch is master, jenkins discare this parameter and always build base images.'
+        )
+        booleanParam(
+            name: 'BuildIfFileChanged',
+            defaultValue: true,
+            description: 'If true, jenkins only builds images which the files are different from master branch. ' +
+                'If current branch is master, jenkins discare this parameter and always build all images.'
         )
     }
     stages {


### PR DESCRIPTION
- If current branch is not master branch, Jenkins builds images which the files are different from master branch.
- Otherwise, Jenkins builds all images