### PR TITLE
ST-2544 Fix Chainer

### DIFF
--- a/env/chainer/3.5/Dockerfile.gpu
+++ b/env/chainer/3.5/Dockerfile.gpu
@@ -3,7 +3,7 @@ FROM $BASE_IMAGE
 
 # Install Chainer and CuPy
 RUN pip install -U \
-    cupy==2.5.0 \
+    cupy==4.4.0 \
     chainer==3.5.0 \
     && rm -rf ~/.cache/pip
 


### PR DESCRIPTION
遇上V100會出現
`cupy.cuda.compiler.CompileException: nvrtc: error: invalid value for --gpu-architecture (-arch)`

- Update CuPy